### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "*" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/rzwarts74/BGPalerter2/security/code-scanning/3](https://github.com/rzwarts74/BGPalerter2/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the `contents: read` permission is sufficient, as the workflow only reads repository contents and uploads artifacts. We will add the `permissions` block at the root level of the workflow to apply it to all jobs (`build` and `test`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
